### PR TITLE
For #9 - Depends on needs to be an array or an object (apparently) fix.

### DIFF
--- a/docker-compose/docker-compose.yaml
+++ b/docker-compose/docker-compose.yaml
@@ -6,7 +6,8 @@ services:
   drupal:
     image: drupal:8.9.19
     container_name: drupal
-    depends_on: db
+    depends_on: 
+      - db
     volumes:
       # the next line should be a path to your backed up site files and it's location within a drupal install
       - ${FILES_PATH}drupal/${DRUPAL_SITE_FILES}:/var/www/${DRUPAL_SITE_FILES}
@@ -40,7 +41,8 @@ services:
   phpmyadmin:
     image: phpmyadmin/phpmyadmin
     container_name: phpmyadmin
-    depends_on: db
+    depends_on: 
+      - db
     restart: always
     environment:
       PMA_HOST: localhost


### PR DESCRIPTION
Running on Ubuntu 20.04 I had the error:
ERROR: The Compose file './docker-compose.yaml' is invalid because:
services.drupal.depends_on contains an invalid type, it should be an array, or an object
services.phpmyadmin.depends_on contains an invalid type, it should be an array, or an object